### PR TITLE
Do not create loadorder.txt when initializing profile

### DIFF
--- a/src/gamenehrim.cpp
+++ b/src/gamenehrim.cpp
@@ -91,7 +91,7 @@ QString GameNehrim::description() const
 
 MOBase::VersionInfo GameNehrim::version() const
 {
-  return VersionInfo(1, 0, 0, VersionInfo::RELEASE_FINAL);
+  return VersionInfo(1, 1, 0, VersionInfo::RELEASE_FINAL);
 }
 
 QList<PluginSetting> GameNehrim::settings() const

--- a/src/gamenehrim.cpp
+++ b/src/gamenehrim.cpp
@@ -103,7 +103,6 @@ void GameNehrim::initializeProfile(const QDir &path, ProfileSettings settings) c
 {
   if (settings.testFlag(IPluginGame::MODS)) {
     copyToProfile(localAppFolder() + "/Oblvion", path, "plugins.txt");
-    copyToProfile(localAppFolder() + "/Oblvion", path, "loadorder.txt");
   }
 
   if (settings.testFlag(IPluginGame::CONFIGURATION)) {


### PR DESCRIPTION
The original intention behind loadorder.txt is to simply report the
load order of plugins to other applications. If the file is not a
known, good load order from MO2, it should not be used to change
the load order.